### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :set_item_find, only: [:edit, :update, :show]
-  before_action :check_item_owner, only: [:edit, :update]
+  before_action :set_item_find, only: [:edit, :update, :show, :destroy]
+  before_action :check_item_owner, only: [:edit, :update, :destroy]
   def index
     @items = Item.all.order('created_at DESC')
   end
@@ -33,6 +33,11 @@ class ItemsController < ApplicationController
   end
 
   def show
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy]
   before_action :set_item_find, only: [:edit, :update, :show, :destroy]
   before_action :check_item_owner, only: [:edit, :update, :destroy]
   def index

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id%>
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
     <% elsif user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
# What
商品削除機能

# Why
売り手が商品を誤って出品した場合や、売るつもりがなくなった際に出品そのものを取りやめる必要があるため

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる
https://gyazo.com/ddd2d2f6eb36588bfd4f5c183c0a45ba